### PR TITLE
delete/edit only on user posts

### DIFF
--- a/API/PostData.js
+++ b/API/PostData.js
@@ -64,10 +64,22 @@ const updatePost = (payload, postId) => new Promise((resolve, reject) => {
     .catch(reject);
 });
 
+const deletePost = (id) => new Promise((resolve, reject) => {
+  fetch(`${endpoint}/posts/${id}`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+    .then((data) => resolve(data))
+    .catch(reject);
+});
+
 export {
   getAllPosts,
   getSinglePost,
   createPost,
   updatePost,
   getAuthUserPosts,
+  deletePost,
 };

--- a/components/ProductCard.js
+++ b/components/ProductCard.js
@@ -2,8 +2,18 @@ import React from 'react';
 import { Button, Card } from 'react-bootstrap';
 import { PropTypes } from 'prop-types';
 import Link from 'next/link';
+import { deletePost } from '../API/PostData';
+import { useAuth } from '../utils/context/authContext';
 
-export default function PostCard({ postObj }) {
+export default function PostCard({ postObj, onUpdate }) {
+  const { user } = useAuth();
+
+  const deleteThisPost = () => {
+    if (window.confirm(`Delete ${postObj.title}?`)) {
+      deletePost(postObj.id).then(() => onUpdate());
+    }
+  };
+
   return (
     <>
       <Card>
@@ -13,9 +23,16 @@ export default function PostCard({ postObj }) {
         <Link href={`/post/${postObj.id}`} passHref>
           <Button>View</Button>
         </Link>
-        <Link href={`/post/edit/${postObj.id}`} passHref>
-          <Button>Edit</Button>
-        </Link>
+        {user && user.id === postObj.userId && (
+          <Link href={`/post/edit/${postObj.id}`} passHref>
+            <Button>Edit</Button>
+          </Link>
+        )}
+        {user && user.id === postObj.userId && (
+          <Button variant="danger" onClick={deleteThisPost} className="m-2">
+            DELETE
+          </Button>
+        )}
       </Card>
     </>
   );
@@ -27,5 +44,7 @@ PostCard.propTypes = {
     title: PropTypes.string,
     imageUrl: PropTypes.string,
     content: PropTypes.string,
+    userId: PropTypes.number,
   }).isRequired,
+  onUpdate: PropTypes.func.isRequired,
 };

--- a/pages/myPosts.js
+++ b/pages/myPosts.js
@@ -42,7 +42,7 @@ export default function ViewMyPosts() {
       className="d-flex flex-wrap"
     >
       {console.warn('userPosts', userPosts)}
-      {userPosts.map((userPost) => (<PostCard postObj={userPost} />))}
+      {userPosts.map((userPost) => (<PostCard postObj={userPost} onUpdate={getAllUsersPosts} />))}
     </div>
   );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- DELETE ALL COMMENTS BEFORE CREATING PULL REQUEST -->

## Description
Made changes so that users can only edit/delete their own posts

## Related Issue
No issues

## Motivation and Context
Wanted to prevent any bugs where anyone can delete anyone's posts. 

## How Can This Be Tested?
Do a git fetch origin DeleteAndEditUserPosts
Git checkout DeleteAndEditUserPosts
Npm Run Dev
Test Away!

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)